### PR TITLE
Use the default https github shorthand

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "dependencies": {
     "ember": "=1.10.0",
-    "ic-styled": "git@github.com:salzhrani/ic-styled.git#8c8d428f3ef652077ccd3f402c89550661612ad8"
+    "ic-styled": "salzhrani/ic-styled#8c8d428f3ef652077ccd3f402c89550661612ad8"
   },
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
It will let you install that bower plugin on a machine that does not have a github.com account.

Thanks for your work
